### PR TITLE
Add the support of installing serving and eventing

### DIFF
--- a/overlay/ke.yaml
+++ b/overlay/ke.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeEventing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version

--- a/overlay/ks.yaml
+++ b/overlay/ks.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeServing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version

--- a/overlay/ks_istio_ns.yaml
+++ b/overlay/ks_istio_ns.yaml
@@ -1,0 +1,22 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeServing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version
+  #@overlay/match missing_ok=True
+  config:
+    #@overlay/match missing_ok=True
+    istio:
+      #@overlay/match missing_ok=True
+      local-gateway.<local_gateway_namespace>.knative-local-gateway: #@ data.values.local_gateway_value

--- a/pkg/command/common/knative_operator.go
+++ b/pkg/command/common/knative_operator.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/operator/pkg/client/clientset/versioned"
+)
+
+const (
+	KnativeServingName  = "knative-serving"
+	KnativeEventingName = "knative-eventing"
+)
+
+// KnativeOperatorCR is used to access the knative custom resource in the Kubernetes cluster.
+type KnativeOperatorCR struct {
+	KnativeOperatorClient *versioned.Clientset
+}
+
+// GetCRInterface gets the Knative custom resource under a certain namespace
+func (ko *KnativeOperatorCR) GetCRInterface(component, namespace string) (interface{}, error) {
+	if strings.EqualFold(component, "serving") {
+		return ko.GetKnativeServing(namespace)
+	} else if strings.EqualFold(component, "eventing") {
+		return ko.GetKnativeEventing(namespace)
+	}
+	return nil, fmt.Errorf("unknow component is set in --component or -c\n")
+}
+
+// GetKnativeServing gets the Knative Serving custom resource under a certain namespace
+func (ko *KnativeOperatorCR) GetKnativeServing(namespace string) (interface{}, error) {
+	knativeServing, err := ko.KnativeOperatorClient.OperatorV1alpha1().KnativeServings(namespace).Get(context.TODO(),
+		KnativeServingName, metav1.GetOptions{})
+
+	serving := &servingv1alpha1.KnativeServing{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KnativeServing",
+			APIVersion: "operator.knative.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KnativeServingName,
+			Namespace: namespace,
+		},
+	}
+
+	if apierrs.IsNotFound(err) {
+		return serving, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	serving.Spec = knativeServing.Spec
+	return serving, nil
+}
+
+// GetKnativeEventing gets the Knative Eventing custom resource under a certain namespace
+func (ko *KnativeOperatorCR) GetKnativeEventing(namespace string) (interface{}, error) {
+	knativeEventing, err := ko.KnativeOperatorClient.OperatorV1alpha1().KnativeEventings(namespace).Get(context.TODO(),
+		KnativeEventingName, metav1.GetOptions{})
+
+	eventing := &eventingv1alpha1.KnativeEventing{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KnativeEventing",
+			APIVersion: "operator.knative.dev/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KnativeEventingName,
+			Namespace: namespace,
+		},
+	}
+
+	if apierrs.IsNotFound(err) {
+		return eventing, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	eventing.Spec = knativeEventing.Spec
+	return knativeEventing, nil
+}

--- a/pkg/command/install/testdata/overlay/ke.yaml
+++ b/pkg/command/install/testdata/overlay/ke.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeEventing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version

--- a/pkg/command/install/testdata/overlay/ks.yaml
+++ b/pkg/command/install/testdata/overlay/ks.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeServing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version

--- a/pkg/command/install/testdata/overlay/ks_istio_ns.yaml
+++ b/pkg/command/install/testdata/overlay/ks_istio_ns.yaml
@@ -1,0 +1,22 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "KnativeServing"}),expects=1
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  #@overlay/match missing_ok=True
+  name: #@ data.values.name
+  #@overlay/match missing_ok=True
+  namespace: #@ data.values.namespace
+#@overlay/match missing_ok=True
+spec:
+  #@overlay/match missing_ok=True
+  version: #@ data.values.version
+  #@overlay/match missing_ok=True
+  config:
+    #@overlay/match missing_ok=True
+    istio:
+      #@overlay/match missing_ok=True
+      local-gateway.<local_gateway_namespace>.knative-local-gateway: #@ data.values.local_gateway_value

--- a/pkg/command/install/testdata/overlay/operator.yaml
+++ b/pkg/command/install/testdata/overlay/operator.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name":"knative-operator"}}),expects=1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ConfigMap"}), expects="1+"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"kind": "ServiceAccount", "metadata":{"name":"knative-operator"}}),expects=1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: #@ data.values.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding"}), expects="1+"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+subjects:
+  #@overlay/match by=overlay.subset({"kind":"ServiceAccount", "name":"knative-operator"})
+  - kind: ServiceAccount
+    name: knative-operator
+    namespace: #@ data.values.namespace


### PR DESCRIPTION
This PR enabled the following features:
* Install Knative Serving/eventing of a certain version, under a certain namespace.
* If Knative operator is not installed, serving/eventing installation will install operator first, and then install the knative component.
* If istio is not under the default ns `istio-system`, specify the istio ns with the flag --istio-namespace for serving, serving will configure accordingly with the operator CR.

Some integration tests will be added to test the functions, that are not covered by unit tests.