### PR TITLE
Add Gateway API ingress support to kn operator plugin

### DIFF
--- a/pkg/command/enable/ingress.go
+++ b/pkg/command/enable/ingress.go
@@ -29,10 +29,11 @@ import (
 var overlayContent string
 
 type ingressFlags struct {
-	Istio     bool
-	Kourier   bool
-	Contour   bool
-	Namespace string
+	Istio      bool
+	Kourier    bool
+	Contour    bool
+	GatewayAPI bool
+	Namespace  string
 }
 
 var ingressCmdFlags ingressFlags
@@ -48,7 +49,9 @@ func newIngressCommand(p *pkg.OperatorParams) *cobra.Command {
   # Enable the ingress kourier for Knative Serving
   kn-operator enable ingress --kourier --namespace knative-serving
   # Enable the ingress contour for Knative Serving
-  kn-operator enable ingress --contour --namespace knative-serving`,
+  kn-operator enable ingress --contour --namespace knative-serving
+  # Enable the ingress gateway-api for Knative Serving
+  kn-operator enable ingress --gateway-api --namespace knative-serving`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := validateIngressFlags(ingressCmdFlags)
 			if err != nil {
@@ -73,6 +76,10 @@ func newIngressCommand(p *pkg.OperatorParams) *cobra.Command {
 				ingress = "Contour"
 			}
 
+			if ingressCmdFlags.GatewayAPI {
+				ingress = "Gateway API"
+			}
+
 			fmt.Fprintf(cmd.OutOrStdout(), "The ingress %s was enabled in the namespace '%s'.\n", ingress, ingressCmdFlags.Namespace)
 			return nil
 		},
@@ -81,6 +88,7 @@ func newIngressCommand(p *pkg.OperatorParams) *cobra.Command {
 	enableIngressCmd.Flags().BoolVar(&ingressCmdFlags.Istio, "istio", false, "The flag to enable the ingress istio")
 	enableIngressCmd.Flags().BoolVar(&ingressCmdFlags.Kourier, "kourier", false, "The flag to enable the ingress kourier")
 	enableIngressCmd.Flags().BoolVar(&ingressCmdFlags.Contour, "contour", false, "The flag to enable the ingress contour")
+	enableIngressCmd.Flags().BoolVar(&ingressCmdFlags.GatewayAPI, "gateway-api", false, "The flag to enable the ingress gateway-api")
 	enableIngressCmd.Flags().StringVarP(&ingressCmdFlags.Namespace, "namespace", "n", "", "The namespace of the Knative Operator or the Knative component")
 
 	return enableIngressCmd
@@ -98,6 +106,10 @@ func validateIngressFlags(ingressCMDFlags ingressFlags) error {
 	}
 
 	if ingressCMDFlags.Contour {
+		count++
+	}
+
+	if ingressCMDFlags.GatewayAPI {
 		count++
 	}
 
@@ -135,8 +147,12 @@ func getYamlValuesContent(ingressCMDFlags ingressFlags) string {
 		ingressClass = "contour.ingress.networking.knative.dev"
 	}
 
-	content := fmt.Sprintf("#@data/values\n---\nnamespace: %s\nkourier: %t\nistio: %t\ncontour: %t\ningressClass: %s",
-		ingressCMDFlags.Namespace, ingressCMDFlags.Kourier, ingressCMDFlags.Istio, ingressCMDFlags.Contour, ingressClass)
+	if ingressCMDFlags.GatewayAPI {
+		ingressClass = "gateway-api.ingress.networking.knative.dev"
+	}
+
+	content := fmt.Sprintf("#@data/values\n---\nnamespace: %s\nkourier: %t\nistio: %t\ncontour: %t\ngatewayAPI: %t\ningressClass: %s",
+		ingressCMDFlags.Namespace, ingressCMDFlags.Kourier, ingressCMDFlags.Istio, ingressCMDFlags.Contour, ingressCMDFlags.GatewayAPI, ingressClass)
 
 	return content
 }

--- a/pkg/command/enable/ingress_test.go
+++ b/pkg/command/enable/ingress_test.go
@@ -33,12 +33,28 @@ func TestValidateIngressFlags(t *testing.T) {
 		ingressCMDFlags: ingressFlags{Istio: true},
 		expectedError:   nil,
 	}, {
+		name:            "Only GatewayAPI enabled",
+		ingressCMDFlags: ingressFlags{GatewayAPI: true},
+		expectedError:   nil,
+	}, {
 		name:            "No ingress enabled",
-		ingressCMDFlags: ingressFlags{Istio: false, Kourier: false, Contour: false},
+		ingressCMDFlags: ingressFlags{Istio: false, Kourier: false, Contour: false, GatewayAPI: false},
 		expectedError:   fmt.Errorf("You need to enable at least one ingress for Knative Serving."),
 	}, {
 		name:            "Istio and Kourier enabled",
 		ingressCMDFlags: ingressFlags{Istio: true, Kourier: true},
+		expectedError:   fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name:            "GatewayAPI and Istio enabled",
+		ingressCMDFlags: ingressFlags{GatewayAPI: true, Istio: true},
+		expectedError:   fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name:            "GatewayAPI and Kourier enabled",
+		ingressCMDFlags: ingressFlags{GatewayAPI: true, Kourier: true},
+		expectedError:   fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name:            "GatewayAPI and Contour enabled",
+		ingressCMDFlags: ingressFlags{GatewayAPI: true, Contour: true},
 		expectedError:   fmt.Errorf("You can specify only one ingress for Knative Serving."),
 	}, {
 		name:            "Istio, Contour and Kourier enabled",
@@ -77,6 +93,7 @@ namespace: test-serving
 kourier: false
 istio: true
 contour: false
+gatewayAPI: false
 ingressClass: istio.ingress.networking.knative.dev`,
 	}, {
 		name: "Knative Serving with Kourier enabled",
@@ -90,6 +107,7 @@ namespace: test-serving
 kourier: true
 istio: false
 contour: false
+gatewayAPI: false
 ingressClass: kourier.ingress.networking.knative.dev`,
 	}, {
 		name: "Knative Serving with Contour enabled",
@@ -103,7 +121,22 @@ namespace: test-serving
 kourier: false
 istio: false
 contour: true
+gatewayAPI: false
 ingressClass: contour.ingress.networking.knative.dev`,
+	}, {
+		name: "Knative Serving with GatewayAPI enabled",
+		ingressCMDFlags: ingressFlags{
+			Namespace:  "test-serving",
+			GatewayAPI: true,
+		},
+		expectedResult: `#@data/values
+---
+namespace: test-serving
+kourier: false
+istio: false
+contour: false
+gatewayAPI: true
+ingressClass: gateway-api.ingress.networking.knative.dev`,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			result := getYamlValuesContent(tt.ingressCMDFlags)

--- a/pkg/command/enable/overlay/ks_ingress.yaml
+++ b/pkg/command/enable/overlay/ks_ingress.yaml
@@ -24,6 +24,10 @@ spec:
     contour:
       #@overlay/match missing_ok=True
       enabled: #@ data.values.contour
+    #@overlay/match missing_ok=True
+    gateway-api:
+      #@overlay/match missing_ok=True
+      enabled: #@ data.values.gatewayAPI
   #@overlay/match missing_ok=True
   config:
     #@overlay/match missing_ok=True

--- a/pkg/command/install/install.go
+++ b/pkg/command/install/install.go
@@ -68,6 +68,7 @@ type installCmdFlags struct {
 	Istio          bool
 	Kourier        bool
 	Contour        bool
+	GatewayAPI     bool
 }
 
 var (
@@ -100,10 +101,11 @@ func (flags *installCmdFlags) fill_defaults() {
 	}
 
 	// Set the default ingress istio to true
-	if strings.EqualFold(flags.Component, common.ServingComponent) && !flags.Kourier && !flags.Contour && !flags.Istio {
+	if strings.EqualFold(flags.Component, common.ServingComponent) && !flags.Kourier && !flags.Contour && !flags.Istio && !flags.GatewayAPI {
 		flags.Istio = true
 		flags.Kourier = false
 		flags.Contour = false
+		flags.GatewayAPI = false
 	}
 }
 
@@ -148,6 +150,7 @@ func NewInstallCommand(p *pkg.OperatorParams) *cobra.Command {
 	installCmd.Flags().BoolVar(&installFlags.Istio, "istio", false, "The flag to enable the ingress istio")
 	installCmd.Flags().BoolVar(&installFlags.Kourier, "kourier", false, "The flag to enable the ingress kourier")
 	installCmd.Flags().BoolVar(&installFlags.Contour, "contour", false, "The flag to enable the ingress contour")
+	installCmd.Flags().BoolVar(&installFlags.GatewayAPI, "gateway-api", false, "The flag to enable the ingress gateway-api")
 
 	return installCmd
 }
@@ -248,6 +251,10 @@ func validateIngressFlags(installFlags *installCmdFlags) error {
 	}
 
 	if installFlags.Contour {
+		count++
+	}
+
+	if installFlags.GatewayAPI {
 		count++
 	}
 
@@ -357,8 +364,12 @@ func getYamlValuesContent(installFlags *installCmdFlags) string {
 		ingressClass = "contour.ingress.networking.knative.dev"
 	}
 
-	content = fmt.Sprintf("%s\nkourier: %t\nistio: %t\ncontour: %t\ningressClass: %s",
-		content, installFlags.Kourier, installFlags.Istio, installFlags.Contour, ingressClass)
+	if installFlags.GatewayAPI {
+		ingressClass = "gateway-api.ingress.networking.knative.dev"
+	}
+
+	content = fmt.Sprintf("%s\nkourier: %t\nistio: %t\ncontour: %t\ngatewayAPI: %t\ningressClass: %s",
+		content, installFlags.Kourier, installFlags.Istio, installFlags.Contour, installFlags.GatewayAPI, ingressClass)
 
 	return content
 }

--- a/pkg/command/install/install_test.go
+++ b/pkg/command/install/install_test.go
@@ -102,6 +102,19 @@ func TestFillDefaultsForInstallCmdFlags(t *testing.T) {
 			Istio:          true,
 		},
 	}, {
+		name: "Empty istio namespace, namespace and version for serving with GatewayAPI",
+		inputFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+		},
+		expectedFlags: installCmdFlags{
+			Component:      "serving",
+			IstioNamespace: common.DefaultIstioNamespace,
+			Namespace:      common.DefaultKnativeServingNamespace,
+			Version:        common.Latest,
+			GatewayAPI:     true,
+		},
+	}, {
 		name: "Empty namespace and version for eventing",
 		inputFlags: installCmdFlags{
 			Component: "eventing",
@@ -151,6 +164,20 @@ func TestGetOverlayYamlContent(t *testing.T) {
 			IstioNamespace: "test",
 		},
 		expectedFile: "testdata/overlay/ks_istio_ns.yaml",
+	}, {
+		name: "Knative Serving with GatewayAPI",
+		installFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+		},
+		expectedFile: "testdata/overlay/ks_ingress.yaml",
+	}, {
+		name: "Knative Serving with Contour",
+		installFlags: installCmdFlags{
+			Component: "serving",
+			Contour:   true,
+		},
+		expectedFile: "testdata/overlay/ks_ingress.yaml",
 	}, {
 		name: "Knative Eventing",
 		installFlags: installCmdFlags{
@@ -248,7 +275,42 @@ version: '1.0'
 kourier: true
 istio: false
 contour: false
+gatewayAPI: false
 ingressClass: kourier.ingress.networking.knative.dev`,
+	}, {
+		name: "Knative Serving with gateway-api and version",
+		installFlags: installCmdFlags{
+			Version:    "1.0",
+			Component:  "serving",
+			GatewayAPI: true,
+		},
+		expectedResult: `#@data/values
+---
+name: knative-serving
+namespace: knative-serving
+version: '1.0'
+kourier: false
+istio: false
+contour: false
+gatewayAPI: true
+ingressClass: gateway-api.ingress.networking.knative.dev`,
+	}, {
+		name: "Knative Serving with contour and version",
+		installFlags: installCmdFlags{
+			Version:   "1.0",
+			Component: "serving",
+			Contour:   true,
+		},
+		expectedResult: `#@data/values
+---
+name: knative-serving
+namespace: knative-serving
+version: '1.0'
+kourier: false
+istio: false
+contour: true
+gatewayAPI: false
+ingressClass: contour.ingress.networking.knative.dev`,
 	}, {
 		name: "Knative Serving with istio and version",
 		installFlags: installCmdFlags{
@@ -323,6 +385,74 @@ namespace: test`,
 			tt.installFlags.fill_defaults()
 			result := getYamlValuesContent(&tt.installFlags)
 			testingUtil.AssertEqual(t, result, tt.expectedResult)
+		})
+	}
+}
+
+func TestValidateIngressFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		installFlags  installCmdFlags
+		expectedError error
+	}{{
+		name: "Serving with only Istio enabled",
+		installFlags: installCmdFlags{
+			Component: "serving",
+			Istio:     true,
+		},
+		expectedError: nil,
+	}, {
+		name: "Serving with only GatewayAPI enabled",
+		installFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+		},
+		expectedError: nil,
+	}, {
+		name: "Serving with GatewayAPI and Istio enabled",
+		installFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+			Istio:      true,
+		},
+		expectedError: fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name: "Serving with GatewayAPI and Kourier enabled",
+		installFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+			Kourier:    true,
+		},
+		expectedError: fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name: "Serving with GatewayAPI and Contour enabled",
+		installFlags: installCmdFlags{
+			Component:  "serving",
+			GatewayAPI: true,
+			Contour:    true,
+		},
+		expectedError: fmt.Errorf("You can specify only one ingress for Knative Serving."),
+	}, {
+		name: "Eventing with GatewayAPI enabled",
+		installFlags: installCmdFlags{
+			Component:  "eventing",
+			GatewayAPI: true,
+		},
+		expectedError: fmt.Errorf("You can only specify the ingress for Knative Serving."),
+	}, {
+		name: "No component with no ingress",
+		installFlags: installCmdFlags{
+			Component: "serving",
+		},
+		expectedError: nil,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIngressFlags(&tt.installFlags)
+			if tt.expectedError == nil {
+				testingUtil.AssertEqual(t, err, nil)
+			} else {
+				testingUtil.AssertEqual(t, err.Error(), tt.expectedError.Error())
+			}
 		})
 	}
 }

--- a/pkg/command/install/overlay/ks_ingress.yaml
+++ b/pkg/command/install/overlay/ks_ingress.yaml
@@ -28,6 +28,10 @@ spec:
     contour:
       #@overlay/match missing_ok=True
       enabled: #@ data.values.contour
+    #@overlay/match missing_ok=True
+    gateway-api:
+      #@overlay/match missing_ok=True
+      enabled: #@ data.values.gatewayAPI
   #@overlay/match missing_ok=True
   config:
     #@overlay/match missing_ok=True

--- a/pkg/command/install/testdata/overlay/ks_ingress.yaml
+++ b/pkg/command/install/testdata/overlay/ks_ingress.yaml
@@ -28,6 +28,10 @@ spec:
     contour:
       #@overlay/match missing_ok=True
       enabled: #@ data.values.contour
+    #@overlay/match missing_ok=True
+    gateway-api:
+      #@overlay/match missing_ok=True
+      enabled: #@ data.values.gatewayAPI
   #@overlay/match missing_ok=True
   config:
     #@overlay/match missing_ok=True


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Add Gateway API as a new ingress option for Knative Serving

This PR adds support for [Gateway API](https://gateway-api.sigs.k8s.io/) as a fourth ingress option in the kn-operator plugin, alongside the existing Istio, Kourier, and Contour options. Gateway API is the successor to the Ingress API and is becoming the standard for traffic management in Kubernetes, making it an important networking option for Knative users.

The implementation follows the same pattern established by the existing ingress options:

- Adds a `--gateway-api` flag to both the `enable ingress` and `install` commands
- Sets the ingress class to `gateway-api.ingress.networking.knative.dev` when Gateway API is selected
- Configures the `spec.ingress.gateway-api.enabled` field in the KnativeServing CR via the YTT overlay templates
- Validates that only one ingress type is selected at a time, consistent with existing behavior
- Includes comprehensive test coverage for all new functionality, including conflict validation with other ingress types

### When to use Gateway API

Consider using Gateway API if your cluster already has a Gateway API-compatible controller installed and you prefer the modern, standards-based approach to Kubernetes ingress management. Gateway API is designed to be the successor to the Ingress API and provides richer routing capabilities.

### Prerequisites

- A Gateway API-compatible controller (e.g., Envoy Gateway, Istio, Contour) must be installed in your cluster
- Gateway API CRDs must be available in your cluster

### Usage

```sh
# Enable Gateway API ingress for Knative Serving
kn-operator enable ingress --gateway-api --namespace knative-serving

# Install Knative Serving with Gateway API ingress
kn-operator install -c serving --gateway-api --namespace knative-serving
```

/kind enhancement

<!-- Please include the 'why' behind your changes if no issue exists -->

Gateway API is becoming the standard for traffic management in Kubernetes (GA since v1.0.0). Adding Gateway API support to the kn-operator plugin allows users to adopt this modern networking option when deploying Knative Serving.

**Release Note**

```release-note
Users can now configure Gateway API as the networking layer for Knative Serving using the `--gateway-api` flag with the `enable ingress` and `install` commands, in addition to the existing Istio, Kourier, and Contour options.
```

**Docs**

```docs
The `enable ingress` and `install` commands now support a `--gateway-api` flag to configure Gateway API as the ingress for Knative Serving. This works the same way as the existing `--istio`, `--kourier`, and `--contour` flags. Only one ingress type can be selected at a time. A Gateway API-compatible controller must be pre-installed in the cluster.
```
